### PR TITLE
Fix tensorflow path on cmake files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CppFlow uses Tensorflow C API to run the models, meaning you can use it without 
 Since it uses TensorFlow C API you just have to [download it](https://www.tensorflow.org/install/lang_c).  
 
 You can either install the library system wide by following the tutorial on the Tensorflow page or you can place the contents of the archive
-in a folder called `libtensorflow` in the root directory of the repo.
+in a folder called `libtensorflow` in the home directory.
 
 Afterwards, you can run the examples:
 
@@ -39,7 +39,7 @@ cd cppflow/examples/load_model
 mkdir build
 cd build
 cmake ..
-make .
+make
 ./example
 ```
 

--- a/examples/coco/CMakeLists.txt
+++ b/examples/coco/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 project(example)
 
+find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow/lib)
+
 set(CMAKE_CXX_STANDARD 17)
+
 add_executable(example main.cpp ../../src/Model.cpp ../../src/Tensor.cpp)
 find_package( OpenCV REQUIRED )
-target_include_directories(example PRIVATE ../../include)
-target_link_libraries (example -ltensorflow ${OpenCV_LIBS})
+target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow/include)
+target_link_libraries (example "${TENSORFLOW_LIB}" ${OpenCV_LIBS})

--- a/examples/load_model/CMakeLists.txt
+++ b/examples/load_model/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(example)
 
+find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow/lib)
+
 set(CMAKE_CXX_STANDARD 17)
 add_executable(example main.cpp ../../src/Model.cpp ../../src/Tensor.cpp)
-target_include_directories(example PRIVATE ../../include)
-target_link_libraries (example -ltensorflow)
+target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow/include)
+target_link_libraries (example "${TENSORFLOW_LIB}")

--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(example)
 
+find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow/lib)
+
 set(CMAKE_CXX_STANDARD 17)
 find_package( OpenCV REQUIRED )
 add_executable(example main.cpp ../../src/Model.cpp ../../src/Tensor.cpp)
-target_include_directories(example PRIVATE ../../include)
-target_link_libraries (example -ltensorflow ${OpenCV_LIBS})
+target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow/include)
+target_link_libraries (example "${TENSORFLOW_LIB}" ${OpenCV_LIBS})


### PR DESCRIPTION
Solves #24 

Following the step by step on README gave error of tensorflow library not found, if you didn't install the library system-wide (i.e., instead you installed on a local folder). 

I fixed it so that it will work if you just put the library on a folder in `$HOME/libtensorflow`. It's very easy to add a relative path to the repository as well, I just don't think it's interesting, but it could be added. 

It's not necessary to change any environment variable (e.g., LD_LIBRARY_PATH) because it's already set up on the executable rpath, so it will always work.  

