### PR TITLE
Added feature for serialized session options

### DIFF
--- a/examples/load_model/create_config_options.py
+++ b/examples/load_model/create_config_options.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+def create_serialized_options(fraction, growth):
+    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=fraction, allow_growth=growth)
+    config = tf.ConfigProto(gpu_options=gpu_options)
+    serialized = config.SerializeToString()
+    return list(map(hex, serialized))
+
+if __name__ == "__main__":
+    print("Create serialized options which allow TF to use a certain percentage of GPU memory and allow TF to expand this memory if required.")
+    for i in range(1, 10):
+        memory_fraction_to_use = 0.1
+        enable_memory_growth = True
+        print("GPU memory to be used: ", i * 10.0, "%")
+        print(create_serialized_options(memory_fraction_to_use, enable_memory_growth))

--- a/examples/load_model/main.cpp
+++ b/examples/load_model/main.cpp
@@ -9,6 +9,13 @@
 #include <iomanip>
 
 int main() {
+    // Load model with a path to the .pb file. 
+    // An optional std::vector<uint8_t> parameter can be used to supply Tensorflow with
+    // session options. The vector must represent a serialized ConfigProto which can be 
+    // generated manually in python. See create_config_options.py.
+    // Example:
+    // const std::vector<uint8_t> ModelConfigOptions = { 0x32, 0xb, 0x9, 0x9a, 0x99, 0x99, 0x99, 0x99, 0x99, 0xb9, 0x3f, 0x20, 0x1 };
+    // Model model("../model.pb", ModelConfigOptions);
     Model model("../model.pb");
     model.init();
 

--- a/include/Model.h
+++ b/include/Model.h
@@ -19,6 +19,7 @@ class Tensor;
 
 class Model {
 public:
+    // Pass a path to the model file and optional Tensorflow config options. See examples/load_model/main.cpp.
     explicit Model(const std::string& model_filename, const std::vector<uint8_t>& config_options = {});
 
     // Rule of five, moving is easy as the pointers can be copied, copying not as i have no idea how to copy

--- a/include/Model.h
+++ b/include/Model.h
@@ -19,7 +19,7 @@ class Tensor;
 
 class Model {
 public:
-    explicit Model(const std::string&);
+    explicit Model(const std::string& model_filename, const std::vector<uint8_t>& config_options = {});
 
     // Rule of five, moving is easy as the pointers can be copied, copying not as i have no idea how to copy
     // the contents of the pointer (i guess dereferencing won't do a deep copy)

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -4,13 +4,18 @@
 
 #include "../include/Model.h"
 
-Model::Model(const std::string& model_filename) {
-
+Model::Model(const std::string& model_filename, const std::vector<uint8_t>& config_options) {
     this->status = TF_NewStatus();
     this->graph = TF_NewGraph();
 
     // Create the session.
     TF_SessionOptions* sess_opts = TF_NewSessionOptions();
+
+    if (!config_options.empty())
+    {
+        TF_SetConfig(sess_opts, static_cast<const void*>(config_options.data()), config_options.size(), this->status);
+        this->status_check(true);
+    }
 
     this->session = TF_NewSession(this->graph, sess_opts, this->status);
     TF_DeleteSessionOptions(sess_opts);


### PR DESCRIPTION
Firstly thank you for creating this library, it has helped us a lot in development. 

Recently we have moved to using Tensorflow on the GPU but to get this working properly along side other software we need to be able to modify TF session options, so that we can control the amount of memory TF uses. This PR allows the user to input options if needed when the model is loaded.