### PR TITLE
cppflow2: Fix compilation with Visual Studio, add How To Run section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,21 @@ As this is still a work under development, there are still many things to do... 
   - Model eager API: Calling model with the eager API instead of the TF_SessionRun API. I have tried using TF_GraphToFunction but I could not achieve it.
   - Cover more raw_ops: Currently, the generator that creates the raw_ops facade converts many of the raw_ops but not all of them. Improve the generator to cover these cases (which are marked in the generator code).
   - Include testing
+
+## How To Run It
+
+Since it uses TensorFlow 2 C API you just have to [download it](https://www.tensorflow.org/install/lang_c).  
+
+You can either install the library system wide by following the tutorial on the Tensorflow page or you can place the contents of the archive in a folder called `libtensorflow2` in the home directory.
+
+Afterwards, you can run the examples:
+
+```sh
+git clone git@github.com:serizba/cppflow.git
+cd cppflow/examples/load_model
+mkdir build
+cd build
+cmake ..
+make
+./example
+```

--- a/examples/efficientnet/CMakeLists.txt
+++ b/examples/efficientnet/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(example)
 
-find_library(TENSORFLOW_LIB tensorflow HINT ../../libtensorflow2/lib)
+find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(example main.cpp ../../include/cppflow/cppflow.h)
-target_include_directories(example PRIVATE ../../include ../../libtensorflow2/include)
+add_executable(example main.cpp)
+target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
 target_link_libraries (example "${TENSORFLOW_LIB}")

--- a/examples/load_model/CMakeLists.txt
+++ b/examples/load_model/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(example)
 
-find_library(TENSORFLOW_LIB tensorflow HINT ../../libtensorflow2/lib)
+find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
 
 set(CMAKE_CXX_STANDARD 17)
 
 add_executable(example main.cpp)
-target_include_directories(example PRIVATE ../../include ../../libtensorflow2/include)
+target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
 target_link_libraries (example "${TENSORFLOW_LIB}")

--- a/include/cppflow/tensor.h
+++ b/include/cppflow/tensor.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <tensorflow/c/tf_tensor.h>
 #include <tensorflow/c/eager/c_api.h>
-#include <bits/shared_ptr.h>
 
 #include "context.h"
 #include "datatype.h"


### PR DESCRIPTION
This unneeded include doesn't compile in Visual Studio. The shared_ptr is part of the <memory> header already.