### PR TITLE
Bug fix: global_context should be inline

### DIFF
--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -40,7 +40,7 @@ namespace cppflow {
     };
 
     // TODO: create ContextManager class if needed
-    static context global_context;
+    inline context global_context;
 
 }
 


### PR DESCRIPTION
Sorry, I introduced a bug in the last PR for `context` refactor. I forgot to change `global_context` from `static` to `inline` after moving it to namespace scope.