### PR TITLE
Remove global variable: global_context in context.h

### DIFF
--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -41,14 +41,20 @@ namespace cppflow {
     };
 
     // TODO: create ContextManager class if needed
-    inline context global_context;
+    // Set new context, thread unsafe, must be called at the beginning.
+    //  TFE_ContextOptions* tfe_opts = ...
+    //  cppflow::get_global_context() = cppflow::context(tfe_opts);
+    inline context& get_global_context() {
+        static context global_context;
+        return global_context;
+    }
 
 }
 
 namespace cppflow {
 
     inline TFE_Context* context::get_context() {
-        return global_context.tfe_context;
+        return get_global_context().tfe_context;
     }
 
     inline TF_Status* context::get_status() {

--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -65,8 +65,8 @@ namespace cppflow {
     inline context::context(TFE_ContextOptions* opts) {
         auto tf_status = context::get_status();
         if(opts == nullptr) {
-            std::unique_ptr<TFE_ContextOptions, decltype(&TFE_DeleteContextOptions)> opts(TFE_NewContextOptions(), &TFE_DeleteContextOptions);
-            this->tfe_context = TFE_NewContext(opts.get(), tf_status);
+            std::unique_ptr<TFE_ContextOptions, decltype(&TFE_DeleteContextOptions)> new_opts(TFE_NewContextOptions(), &TFE_DeleteContextOptions);
+            this->tfe_context = TFE_NewContext(new_opts.get(), tf_status);
         } else {
             this->tfe_context = TFE_NewContext(opts, tf_status);
         }


### PR DESCRIPTION
Fix #87, #82, #83, deadlock in windows DLL load due to global variable initialization.