### PR TITLE
`context::operator=()` leaks `tfe_context`

### DIFF
--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -79,7 +79,7 @@ namespace cppflow {
     }
 
     inline context& context::operator=(context&& ctx) noexcept {
-        tfe_context = std::exchange(ctx.tfe_context, nullptr);
+        tfe_context = std::exchange(ctx.tfe_context, tfe_context);
         return *this;
     }
 


### PR DESCRIPTION
Fix memory leak. Previously old `this->tfe_context` would not be deleted