### PR TITLE
Fix type casting error on example code

### DIFF
--- a/examples/tensor/main.cpp
+++ b/examples/tensor/main.cpp
@@ -67,7 +67,7 @@ void test1(const bool is_cpu) {
     }
 
     auto shape_tensor = t1.shape();
-    auto shape = shape_tensor.get_data<int32_t>()[0];
+    auto shape = shape_tensor.get_data<int64_t>()[0];
     if(shape == ndim) {
         std::cout << "tensor::get_tensor() test1-5: pass" << std::endl;
     } else {


### PR DESCRIPTION
After update the type check function (9b05be62743ccd6232776c6af6ebc1ccdda7b317), An error occurs in the example code.

I changed the casting type `int32_t` to `int64_t`.