### PR TITLE
throw error if operation name is NoOp

### DIFF
--- a/include/cppflow/model.h
+++ b/include/cppflow/model.h
@@ -89,6 +89,9 @@ namespace cppflow {
         if (!out_op.oper)
             throw std::runtime_error("No operation named \"" + operation + "\" exists");
 
+        if (operation == "NoOp")
+             throw std::runtime_error("NoOp doesn't have a shape");
+
         // DIMENSIONS
 
         // Get number of dimensions


### PR DESCRIPTION
Even if the model contains a NoOp operation, we should prevent invocating the `get_operation_shape` method passing "NoOp".

This is required because if you Invoke the `TF_GraphGetTensorNumDims` when the input is "NoOp", this C function of the TensorFlow API crashes