### PR TITLE
Add modern cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ examples/*/build
 
 # Libtensorflow
 libtensorflow
+
+# Downloaded model
+examples/efficientnet/model

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+project(cppflow LANGUAGES CXX)
+
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake)
+
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_SOURCE_DIR}/cmake/modules")
+
+
+# Library target
+find_package(tensorflow REQUIRED)
+add_library(cppflow INTERFACE)
+target_include_directories(cppflow
+  INTERFACE
+    ${tensorflow_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_compile_features(cppflow INTERFACE cxx_std_17)
+target_link_libraries(cppflow INTERFACE
+  ${tensorflow_LIBRARIES}
+)
+install(
+  TARGETS cppflow
+  EXPORT install_targets
+)
+
+
+# Build examples
+option(BUILD_EXAMPLES "Build examples" ON)
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+
+# Install headers
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+
+# Install targets file
+install(EXPORT install_targets
+  FILE
+    ${PROJECT_NAME}Targets.cmake
+  NAMESPACE
+    ${PROJECT_NAME}::
+  DESTINATION
+    ${INSTALL_CONFIGDIR}
+)
+
+
+# Install cppflowConfig.cmake
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+
+# Install find modules
+install(DIRECTORY cmake/modules/ DESTINATION ${INSTALL_CONFIGDIR}/modules)

--- a/cmake/cppflowConfig.cmake.in
+++ b/cmake/cppflowConfig.cmake.in
@@ -1,0 +1,7 @@
+get_filename_component(cppflow_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+if(NOT TARGET cppflow::cppflow)
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${cppflow_CMAKE_DIR}/modules")
+  find_package(tensorflow REQUIRED)
+  include("${cppflow_CMAKE_DIR}/cppflowTargets.cmake")
+endif()

--- a/cmake/modules/Findtensorflow.cmake
+++ b/cmake/modules/Findtensorflow.cmake
@@ -1,0 +1,20 @@
+find_path(tensorflow_INCLUDE_DIRS
+  NAMES tensorflow/c/c_api.h
+)
+mark_as_advanced(tensorflow_INCLUDE_DIRS)
+
+find_library(tensorflow_LIBRARIES
+  NAMES tensorflow
+)
+mark_as_advanced(tensorflow_LIBRARIES)
+
+
+if(NOT tensorflow_INCLUDE_DIRS)
+  message(STATUS "Could NOT find tensorflow/c/c_api.h")
+endif()
+if(NOT tensorflow_LIBRARIES)
+  message(STATUS "Could NOT find tensorflow library")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(tensorflow DEFAULT_MSG tensorflow_INCLUDE_DIRS tensorflow_LIBRARIES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(eager_op_multithread)
+add_subdirectory(efficientnet)
+add_subdirectory(load_model)
+add_subdirectory(multi_input_output)
+add_subdirectory(tensor)

--- a/examples/eager_op_multithread/CMakeLists.txt
+++ b/examples/eager_op_multithread/CMakeLists.txt
@@ -1,14 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
-project(example)
+project(eager_op_multithread)
 
-find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
 find_package(Threads REQUIRED)
-
-set(CMAKE_CXX_STANDARD 17)
 
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
 #set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=thread")
 
-add_executable(example main.cpp)
-target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries(example "${TENSORFLOW_LIB}" Threads::Threads)
+add_executable(eager_op_multithread main.cpp)
+target_link_libraries(eager_op_multithread Threads::Threads cppflow)

--- a/examples/efficientnet/CMakeLists.txt
+++ b/examples/efficientnet/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
-project(example)
+project(efficientnet)
 
-find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
-
-set(CMAKE_CXX_STANDARD 17)
-
-add_executable(example main.cpp)
-target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries (example "${TENSORFLOW_LIB}")
+add_executable(efficientnet main.cpp)
+target_link_libraries(efficientnet cppflow)
+target_compile_definitions(efficientnet PUBLIC
+  CAT_PATH="${CMAKE_CURRENT_SOURCE_DIR}/my_cat.jpg"
+  MODEL_PATH="${CMAKE_CURRENT_SOURCE_DIR}/model"
+)

--- a/examples/efficientnet/main.cpp
+++ b/examples/efficientnet/main.cpp
@@ -5,13 +5,13 @@
 
 int main() {
 
-    auto input = cppflow::decode_jpeg(cppflow::read_file(std::string("../my_cat.jpg")));
+    auto input = cppflow::decode_jpeg(cppflow::read_file(std::string(CAT_PATH)));
     input = cppflow::cast(input, TF_UINT8, TF_FLOAT);
     input = cppflow::expand_dims(input, 0);
-    cppflow::model model("../model");
+    cppflow::model model(std::string(MODEL_PATH));
     auto output = model(input);
 
     std::cout << "It's a tiger cat: " << cppflow::arg_max(output, 1) << std::endl;
-    
+
     return 0;
 }

--- a/examples/load_model/CMakeLists.txt
+++ b/examples/load_model/CMakeLists.txt
@@ -1,12 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
-project(example)
+project(load_model)
 
-find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
-
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
 set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lasan")
 
-add_executable(example main.cpp)
-target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries (example "${TENSORFLOW_LIB}")
+add_executable(load_model main.cpp)
+target_link_libraries(load_model cppflow)
+target_compile_definitions(load_model PUBLIC
+  MODEL_PATH="${CMAKE_CURRENT_SOURCE_DIR}/model"
+)

--- a/examples/load_model/main.cpp
+++ b/examples/load_model/main.cpp
@@ -7,9 +7,9 @@
 int main() {
 
     auto input = cppflow::fill({10, 5}, 1.0f);
-    cppflow::model model("../model");
+    cppflow::model model(std::string(MODEL_PATH));
     auto output = model(input);
-    
+
     std::cout << output << std::endl;
 
     auto values = output.get_data<float>();

--- a/examples/multi_input_output/CMakeLists.txt
+++ b/examples/multi_input_output/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
-project(example)
+project(multi_input_output)
 
-find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
-
-set(CMAKE_CXX_STANDARD 17)
-
-add_executable(example main.cpp)
-target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries (example "${TENSORFLOW_LIB}")
+add_executable(multi_input_output main.cpp)
+target_link_libraries(multi_input_output cppflow)
+target_compile_definitions(multi_input_output PUBLIC
+  MODEL_PATH="${CMAKE_CURRENT_SOURCE_DIR}/model"
+)

--- a/examples/multi_input_output/main.cpp
+++ b/examples/multi_input_output/main.cpp
@@ -7,7 +7,7 @@ int main() {
 
     auto input_1 = cppflow::fill({10, 5}, 1.0f);
     auto input_2 = cppflow::fill({10, 5}, -1.0f);
-    cppflow::model model("../model");
+    cppflow::model model(std::string(MODEL_PATH));
 
     auto output = model({{"serving_default_my_input_1:0", input_1}, {"serving_default_my_input_2:0", input_2}}, {"StatefulPartitionedCall:0", "StatefulPartitionedCall:1"});
 

--- a/examples/tensor/CMakeLists.txt
+++ b/examples/tensor/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(example)
+project(tensor)
 
-find_library(TENSORFLOW_LIB tensorflow HINT $ENV{HOME}/libtensorflow2/lib)
-
-set(CMAKE_CXX_STANDARD 17)
-
-add_executable(example main.cpp odr.cpp)
-target_include_directories(example PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries(example "${TENSORFLOW_LIB}")
+add_executable(tensor main.cpp odr.cpp)
+target_link_libraries(tensor cppflow)


### PR DESCRIPTION
This adds support for building and installing this package with cmake, so that it can be used from other packages with a simple cmake interface and without having to copy headers:

- Add cmake interface so that the installed library can be used from other projects via `find_package(cppflow)` and `target_link_libraries(new_target PUBLIC cppflow)`
- Simplify examples cmake code by using the new cmake interface
- Build all examples unless `-DBUILD_EXAMPLES=OFF` is passed
- Enable out-of-source build by fixing hard-coded paths

An example out-of-source build would look like this:
```
git clone https://github.com/serizba/cppflow
cd cppflow
mkdir build
cd build
cmake -DBUILD_EXAMPLES=ON ..
make -j8

# Test run one of the examples
./examples/multi_input_output/multi_input_output

# This installs c++ code and cmake interface to system directories and enables other packages to find cppflow via 'find_package(cppflow)'
make install 
```