### PR TITLE
Avoid default global context initialization before session options are provided.

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -140,8 +140,10 @@ You can specify TensorFlow's GPU Options to prevent it from reserving all your G
     // Create new options with your configuration
     TFE_ContextOptions* options = TFE_NewContextOptions();
     TFE_ContextOptionsSetConfig(options, config.data(), config.size(), cppflow::context::get_status());
-    // Replace the global context with your options
-    cppflow::get_global_context() = cppflow::context(options);
+    // Initialize the global context with your options
+    cppflow::context::set_context_options(options);
+    // Delete options
+    TFE_DeleteContextOptions(options);
 
 To obtain your desired serialized config options you can just run a small python script to print them:
 

--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -21,40 +21,56 @@ namespace cppflow {
         return true;
     }
 
+    // Tensorflow only allows single context per process.
+    // Setting different session options may cause undefined behaviors, see
+    // https://github.com/tensorflow/tensorflow/issues/19083
+    // https://github.com/tensorflow/tensorflow/issues/18861
+    // Usage: Call cppflow::context::set_context_options(opts) if you need to set a session option.
+    // Note that you also need to use the same session option when you load a model.
     class context {
         public:
+            // Get global singleton context
+            static const context& get_singleton();
             static TFE_Context* get_context();
             static TF_Status* get_status();
+
+            // Set global context options, thread unsafe, must be called at the beginning.
+            // Only the first call is valid. Later calls have no effect, but no error either.
+            // Does NOT take over ownership of opts. Caller needs to deallocate opts.
+            static void set_context_options(TFE_ContextOptions* opts);
 
         private:
             TFE_Context* tfe_context{nullptr};
 
-        public:
-            explicit context(TFE_ContextOptions* opts = nullptr);
+            // Only used in set_context_options() and the constructor
+            // Avoid passing in arguments while calling get_singleton()
+            // Set to nullptr thereafter, no need to deallocate in deconstructor
+            static TFE_ContextOptions* tfe_context_options;
 
+            context();
+
+        public:
             context(context const&) = delete;
             context& operator=(context const&) = delete;
-            context(context&&) noexcept;
-            context& operator=(context&&) noexcept;
+            context(context&&) = delete;
+            context& operator=(context&&) = delete;
 
             ~context();
     };
-
-    // TODO: create ContextManager class if needed
-    // Set new context, thread unsafe, must be called at the beginning.
-    //  TFE_ContextOptions* tfe_opts = ...
-    //  cppflow::get_global_context() = cppflow::context(tfe_opts);
-    inline context& get_global_context() {
-        static context global_context;
-        return global_context;
-    }
-
 }
 
 namespace cppflow {
 
+    // C++17, move this to a cpp file and remove inline if compiled with C++14
+    inline TFE_ContextOptions* context::tfe_context_options{nullptr};
+
+    inline const context& context::get_singleton() {
+        static context global_context;
+        return global_context;
+    }
+
     inline TFE_Context* context::get_context() {
-        return get_global_context().tfe_context;
+        return get_singleton().tfe_context;
     }
 
     inline TF_Status* context::get_status() {
@@ -62,25 +78,19 @@ namespace cppflow {
         return local_tf_status.get();
     }
 
-    inline context::context(TFE_ContextOptions* opts) {
+    inline void context::set_context_options(TFE_ContextOptions* opts) {
+        tfe_context_options = opts;
+        context::get_singleton();
+        tfe_context_options = nullptr;
+    }
+
+    inline context::context() {
         auto tf_status = context::get_status();
-        if(opts == nullptr) {
-            std::unique_ptr<TFE_ContextOptions, decltype(&TFE_DeleteContextOptions)> new_opts(TFE_NewContextOptions(), &TFE_DeleteContextOptions);
-            this->tfe_context = TFE_NewContext(new_opts.get(), tf_status);
-        } else {
-            this->tfe_context = TFE_NewContext(opts, tf_status);
+        if(tfe_context_options == nullptr) {
+            tfe_context_options = TFE_NewContextOptions();
         }
+        this->tfe_context = TFE_NewContext(tfe_context_options, tf_status);
         status_check(tf_status);
-    }
-
-    inline context::context(context&& ctx) noexcept :
-        tfe_context(std::exchange(ctx.tfe_context, nullptr))
-    {
-    }
-
-    inline context& context::operator=(context&& ctx) noexcept {
-        tfe_context = std::exchange(ctx.tfe_context, tfe_context);
-        return *this;
     }
 
     inline context::~context() {

--- a/include/cppflow/model.h
+++ b/include/cppflow/model.h
@@ -19,7 +19,8 @@ namespace cppflow {
 
     class model {
     public:
-        explicit model(const std::string& filename);
+        // NOTE: TF_SessionOptions here has to be the same as cppflow::context::set_context_options(opts);
+        explicit model(const std::string& filename, const TF_SessionOptions* opts = nullptr);
 
         std::vector<std::string> get_operations() const;
         std::vector<int64_t> get_operation_shape(const std::string& operation) const;
@@ -43,7 +44,7 @@ namespace cppflow {
 
 namespace cppflow {
 
-    inline model::model(const std::string &filename) {
+    inline model::model(const std::string &filename, const TF_SessionOptions* opts) {
         this->graph = {TF_NewGraph(), TF_DeleteGraph};
 
         // Create the session.
@@ -58,7 +59,8 @@ namespace cppflow {
 
         int tag_len = 1;
         const char* tag = "serve";
-        this->session = {TF_LoadSessionFromSavedModel(session_options.get(), run_options.get(), filename.c_str(),
+        if(!opts) opts = session_options.get();
+        this->session = {TF_LoadSessionFromSavedModel(opts, run_options.get(), filename.c_str(),
                                 &tag, tag_len, this->graph.get(), meta_graph.get(), context::get_status()),
                          session_deleter};
 


### PR DESCRIPTION
Try to ensure only a single context is created per process.

For example, in multi-GPU environment, the default context tries to use all the GPU. Limiting GPU usage by remapping GPU using session options is not possible.

Fix #126 