### PR TITLE
add TString deallocation step

### DIFF
--- a/include/cppflow/tensor.h
+++ b/include/cppflow/tensor.h
@@ -157,6 +157,7 @@ namespace cppflow {
         TF_TString_Copy(&tstr[0], value.c_str(), value.size());
 
         *this = tensor(static_cast<enum TF_DataType>(TF_STRING), (void *) tstr, sizeof(tstr), {});
+        TF_TString_Dealloc(&tstr[0]);
     }
 #else
     template<>


### PR DESCRIPTION
When I compare TString usage in cppflow and tensorflow's unittest, it seems that deallocation step may be required. But I did not check actual implementation of TString, so if I am wrong, please let it go.

https://github.com/tensorflow/tensorflow/blob/2305f9d0a58921987788fbd1d8fa43eda888233f/tensorflow/core/platform/ctstring_test.cc#L34-L68