### PR TITLE
Fix error when destructing a static std::unique_ptr<cppflow::model>

### DIFF
--- a/include/cppflow/model.h
+++ b/include/cppflow/model.h
@@ -52,8 +52,10 @@ namespace cppflow {
         std::unique_ptr<TF_Buffer, decltype(&TF_DeleteBuffer)> meta_graph = {TF_NewBuffer(), TF_DeleteBuffer};
 
         auto session_deleter = [](TF_Session* sess) {
-            TF_DeleteSession(sess, context::get_status());
-            status_check(context::get_status());
+            auto status = TF_NewStatus();
+            TF_DeleteSession(sess, status);
+            status_check(status);
+            TF_DeleteStatus(status);
         };
 
         int tag_len = 1;


### PR DESCRIPTION
Fixes #131 

When creating a static version of a reference to a `cppflow::model`,
there becomes an error when destructing, due to the
`context::get_status()` method using a `thread_local` status. While
this is done normally for performance gains and is fine in most
places. However, when the program is exiting, it first destructs `thread_local`
objects and then `static` ones. This leads to `local_tf_status`
containing a `nullptr` instead of a pointer to a `TF_Status`
object. Therefore, `TF_DeleteSession(sess, status)` fails because it
access `*status`. The simplest fix is to not re-use this status object
in the destructor of the session and instead make a new,
non-`thread_local` status instead.