### PR TITLE
Use per model TF_Status instead of the global one

### DIFF
--- a/include/cppflow/context.h
+++ b/include/cppflow/context.h
@@ -24,6 +24,8 @@ namespace cppflow {
     class context {
         public:
             static TFE_Context* get_context();
+
+            // only use get_status() for eager ops
             static TF_Status* get_status();
 
         private:


### PR DESCRIPTION
This avoids the initialization order issues when people build cppflow into a library, e.g. a dll.

Should fix #132, #195, #163, #131, #190, #154
