### PR TITLE
Added tensor constructors and get_raw_data to work with pointers of p…

### DIFF
--- a/include/cppflow/model.h
+++ b/include/cppflow/model.h
@@ -25,6 +25,7 @@ namespace cppflow {
             FROZEN_GRAPH,
         };
 
+	    model() = default;
         explicit model(const std::string& filename, const TYPE type=TYPE::SAVED_MODEL);
 
         std::vector<std::string> get_operations() const;

--- a/include/cppflow/tensor.h
+++ b/include/cppflow/tensor.h
@@ -80,20 +80,29 @@ namespace cppflow {
         datatype dtype() const;
 
         /**
-         * Converts the tensor into a C++ vector
-         * @tparam T The c++ type (must be equivalent to the tensor type)
-         * @return A vector representing the flat tensor
-         */
-        template<typename T>
-        std::vector<T> get_data() const;
-
-        /**
          * Converts the tensor into a pointer of primitive type T
          * @tparam T The c++ type (must be equivalent to the tensor type)
          * @return A pointer of type T representing the flat tensor
          */
         template<typename T>
         T *get_raw_data() const;
+
+        /**
+         * Converts the tensor into a pointer of primitive type T
+         * @tparam T The c++ type (must be equivalent to the tensor type)
+         * @return A pointer of type T representing the flat tensor
+         * @return The size of the array
+         */
+        template<typename T>
+        T *get_raw_data(size_t &size) const;
+
+        /**
+         * Converts the tensor into a C++ vector
+         * @tparam T The c++ type (must be equivalent to the tensor type)
+         * @return A vector representing the flat tensor
+         */
+        template<typename T>
+        std::vector<T> get_data() const;
 
         ~tensor() = default;
         tensor(const tensor &tensor) = default;
@@ -235,17 +244,17 @@ namespace cppflow {
         return res;
     }
 
+
     template<typename T>
-    std::vector<T> tensor::get_data() const {
+    T *tensor::get_raw_data(size_t &size) const {
 
         // Check if asked datatype and tensor datatype match
         if (this->dtype() != deduce_tf_type<T>()) {
             auto type1 = cppflow::to_string(deduce_tf_type<T>());
             auto type2 = cppflow::to_string(this->dtype());
-            auto error = "Datatype in function get_data (" + type1 + ") does not match tensor datatype (" + type2 + ")";
+            auto error = "Datatype in function get_raw_data (" + type1 + ") does not match tensor datatype (" + type2 + ")";
             throw std::runtime_error(error);
         }
-
 
         auto res_tensor = get_tensor();
 
@@ -253,39 +262,34 @@ namespace cppflow {
         auto raw_data = TF_TensorData(res_tensor.get());
         //this->error_check(raw_data != nullptr, "Tensor data is empty");
 
-        size_t size = TF_TensorByteSize(res_tensor.get()) / TF_DataTypeSize(TF_TensorType(res_tensor.get()));
-
-        // Convert to correct type
-        const auto T_data = static_cast<T*>(raw_data);
-        std::vector<T> r(T_data, T_data + size);
-
-        return r;
-    }
-
-    template<typename T>
-    T *tensor::get_raw_data() const {
-
-        // Check if asked datatype and tensor datatype match
-        if (this->dtype() != deduce_tf_type<T>()) {
-            auto type1 = cppflow::to_string(deduce_tf_type<T>());
-            auto type2 = cppflow::to_string(this->dtype());
-            auto error = "Datatype in function get_data (" + type1 + ") does not match tensor datatype (" + type2 + ")";
-            throw std::runtime_error(error);
-        }
-
-
-        auto res_tensor = get_tensor();
-
-        // Check tensor data is not empty
-        auto raw_data = TF_TensorData(res_tensor.get());
-        //this->error_check(raw_data != nullptr, "Tensor data is empty");
-
-        size_t size = TF_TensorByteSize(res_tensor.get()) / TF_DataTypeSize(TF_TensorType(res_tensor.get()));
+        // Get size of array
+        size = TF_TensorByteSize(res_tensor.get()) / TF_DataTypeSize(TF_TensorType(res_tensor.get()));
 
         // Convert to correct type
         const auto T_data = static_cast<T*>(raw_data);
 
         return T_data;
+    }
+
+    template<typename T>
+    T *tensor::get_raw_data() const {
+
+        // Get the raw data and return
+        size_t size = 0;
+        const auto T_data = this->get_raw_data<T>(size);
+
+        return T_data;
+    }
+
+    template<typename T>
+    std::vector<T> tensor::get_data() const {
+        
+        // Get the raw data and size of array
+        size_t size = 0;
+        const auto T_data = this->get_raw_data<T>(size);
+        std::vector<T> r(T_data, T_data + size);
+
+        return r;
     }
 
     inline datatype tensor::dtype() const {


### PR DESCRIPTION
Since most scientific computing codes don't use std::vector and use their own containers, new tensor constructor and get_raw_data functions were added to work with pointers of primitive types. 