### PR TITLE
Added method to create tensors and models from data in memory.

### DIFF
--- a/include/cppflow/tensor.h
+++ b/include/cppflow/tensor.h
@@ -96,6 +96,18 @@ class tensor {
   tensor &operator=(const tensor &other) = default;
   tensor &operator=(tensor &&other) = default;
 
+
+  /**
+  * Static method to create a tensor from a raw buffer
+  * @param data A pointer to the raw data used to initialize the tensor
+  * @param len The length of the buffer in bytes
+  * @param shape The shape of the requested tensor
+  * @param type The type contained in the data buffer
+  */
+  static tensor create_from_raw_data(const void* data, size_t len, const std::vector<int64_t>& shape, enum TF_DataType type) {
+      return tensor(type, data, len, shape);
+  }
+
   /**
    * @return Shape of the tensor
    */


### PR DESCRIPTION
Added static member to tensor class to allows the creation of a tensor directly from an existing buffer without having to create a copy as a std:vector. Specially useful when the input already exists in raw format in memory and has a significant footprint.
Also added member to model class to allow building a model from a buffer already in memory that's been loaded with the content of a saved model file. While this use case may appear obscure, there are cases where a stand-alone application needs to be distributed with encrypted models that are only decrypted in memory.
Note: the fix on the status member was an oversight while merging my old codebase with the new fork of cppflow:master. The new fixed constructor model compiles and runs as expected.